### PR TITLE
Version 3.0

### DIFF
--- a/Resources.lua
+++ b/Resources.lua
@@ -246,7 +246,7 @@ function Resources:LoadLibrary(LibraryName)
 					String = String .. " -> " .. Current
 				end
 
-				error("[Resources] Attempt to do circular library requiring: " .. String)
+				error("[Resources] Circular dependency chain detected: " .. String)
 			end
 		end
 

--- a/Resources.lua
+++ b/Resources.lua
@@ -213,6 +213,7 @@ end
 
 local LoadedLibraries = Resources:GetLocalTable("LoadedLibraries")
 local CurrentlyLoading = {} -- This is a hash which functions as a kind of linked-list history of [Script who Loaded] -> Library
+local Nil = newproxy(false) -- How we store nil values
 
 function Resources:LoadLibrary(LibraryName)
 	LibraryName = self ~= Resources and self or LibraryName
@@ -250,16 +251,24 @@ function Resources:LoadLibrary(LibraryName)
 			end
 		end
 
-		Data = require(Library) or false
+		Data = require(Library)
 
 		if CurrentlyLoading[Caller] == Library then -- Thread-safe cleanup!
 			CurrentlyLoading[Caller] = nil
 		end
 
+		if Data == nil then
+			Data = Nil
+		end
+
 		LoadedLibraries[LibraryName] = Data -- Cache by name for subsequent calls
 	end
 
-	return Data
+	if Data == Nil then
+		return nil
+	else
+		return Data
+	end
 end
 
 Metatable.__call = Resources.LoadLibrary

--- a/Resources.lua
+++ b/Resources.lua
@@ -197,7 +197,7 @@ else
 		HandleFolderChildren(LibraryRepository:GetChildren(), false)
 
 		for Name, Library in next, ServerLibraries do
-			if ReplicatedLibraries[Name] then
+			if not ShouldReplicate and ReplicatedLibraries[Name] then
 				warn("[Resources] In the absence of a client, the client-version of", Name, "will be inaccessible")
 			end
 			ReplicatedLibraries[Name] = Library


### PR DESCRIPTION
- Updated Documentation to describe code behavior
- Simplify recursive implementation (which only runs once at start-up on the server)
- Rewrite replication functionality to match new docs
- Specify which storage in which there are duplicate libraries if an error is necessary

UPDATE:
- Fix ServerOnly detection
- Change `CurrentlyLoading` to a hash of references instead of string Names
    - This is used for detecting circular dependency chain errors
- Error bad calls to GetLibrary before checking circular dependencies
- Fixed PlaySolo warning from appearing on normal servers

UPDATE 2:
- Make `nil` values cache properly